### PR TITLE
Update NPC system to allow custom greetwords usage.

### DIFF
--- a/data/npc/lib/npcsystem/modules.lua
+++ b/data/npc/lib/npcsystem/modules.lua
@@ -189,7 +189,9 @@ if Modules == nil then
 	end
 
 	FocusModule = {
-		npcHandler = nil
+		npcHandler = nil,
+		greetWords = nil,
+		farewellWords = nil
 	}
 
 	-- Creates a new instance of FocusModule without an associated NpcHandler.
@@ -203,14 +205,17 @@ if Modules == nil then
 	-- Inits the module and associates handler to it.
 	function FocusModule:init(handler)
 		self.npcHandler = handler
-		for i, word in pairs(FOCUS_GREETWORDS) do
+		local greetWords = self.greetWords or FOCUS_GREETWORDS
+		local farewellWords = self.farewellWords or FOCUS_FAREWELLWORDS
+		
+		for i, word in pairs(greetWords) do
 			local obj = {}
 			obj[#obj + 1] = word
 			obj.callback = FOCUS_GREETWORDS.callback or FocusModule.messageMatcher
 			handler.keywordHandler:addKeyword(obj, FocusModule.onGreet, {module = self})
 		end
 
-		for i, word in pairs(FOCUS_FAREWELLWORDS) do
+		for i, word in pairs(farewellWords) do
 			local obj = {}
 			obj[#obj + 1] = word
 			obj.callback = FOCUS_FAREWELLWORDS.callback or FocusModule.messageMatcher
@@ -219,10 +224,36 @@ if Modules == nil then
 
 		return true
 	end
-
+	
+	-- Set custom greeting messages
+	function FocusModule:addGreetMessage(message)
+		if not self.greetWords then
+			self.greetWords = {}
+		end
+		
+		if type(message) == "table" then
+			for k, v in pairs(message) do
+				table.insert(self.greetWords, v)
+			end
+		end
+	end
+	
+	-- Set custom farewell messages
+	function FocusModule:addFarewellMessage(message)
+		if not self.farewellWords then
+			self.farewellWords = {}
+		end
+		
+		if type(message) == "table" then
+			for k, v in pairs(message) do
+				table.insert(self.farewellWords, v)
+			end
+		end
+	end
+	
 	-- Greeting callback function.
 	function FocusModule.onGreet(cid, message, keywords, parameters)
-		parameters.module.npcHandler:onGreet(cid)
+		parameters.module.npcHandler:onGreet(cid, message)
 		return true
 	end
 

--- a/data/npc/lib/npcsystem/npchandler.lua
+++ b/data/npc/lib/npcsystem/npchandler.lua
@@ -372,10 +372,10 @@ if NpcHandler == nil then
 	end
 
 	-- Greets a new player.
-	function NpcHandler:greet(cid)
+	function NpcHandler:greet(cid, message)
 		if cid ~= 0 then
 			local callback = self:getCallback(CALLBACK_GREET)
-			if callback == nil or callback(cid) then
+			if callback == nil or callback(cid, message) then
 				if self:processModuleCallback(CALLBACK_GREET, cid) then
 					local msg = self:getMessage(MESSAGE_GREET)
 					local player = Player(cid)
@@ -541,16 +541,16 @@ if NpcHandler == nil then
 	end
 
 	-- Tries to greet the player with the given cid.
-	function NpcHandler:onGreet(cid)
+	function NpcHandler:onGreet(cid, message)
 		if self:isInRange(cid) then
-            if(NPCHANDLER_CONVBEHAVIOR == CONVERSATION_PRIVATE) then
-                if not self:isFocused(cid) then
-                    self:greet(cid)
-                    return
-                end
+			if(NPCHANDLER_CONVBEHAVIOR == CONVERSATION_PRIVATE) then
+				if not self:isFocused(cid) then
+				self:greet(cid, message)
+					return
+				end
 			elseif(NPCHANDLER_CONVBEHAVIOR == CONVERSATION_DEFAULT) then
 				if(self.focuses == 0) then
-					self:greet(cid)
+					self:greet(cid, message)
 				elseif(self.focuses == cid) then
 					local msg = self:getMessage(MESSAGE_ALREADYFOCUSED)
 					local parseInfo = { [TAG_PLAYERNAME] = getCreatureName(cid) }


### PR DESCRIPTION
Change 1)
This change adds custom greet/farewell message handling. It adds two functions:

focusModule:addGreetMessage({"hi", "hello", "ashari"})
focusModule:addFarewellMessage({"bye", "farewell", "asha thrazi"})

Both of them use local instances of npcHandler to guarantee separation, which means that any NPC can have its own table of custom focus greet/farewell messages. Ofcourse using these functions is optional. An engine will use generic FOCUS_GREETWORDS or FOCUS_FAREWELLWORDS if user doesn't set his own custom string table. Everything is compatible with current system.

I'm not an author of this code. I don't know who is. Huge part of it has been taken from Alkurius and Realera. I only made an adaptation.

Change 2)
This change adds possibility of using param msg in greetCallback, so people may use:
local function greetCallback(cid, msg) or as previously:
local function greetCallback(cid)

If you decide to add these changes to master branch, I will show people on Otland how to use it.