### PR TITLE
nil tile crash fix

### DIFF
--- a/data/movements/scripts/tiles.lua
+++ b/data/movements/scripts/tiles.lua
@@ -25,11 +25,14 @@ function onStepIn(creature, item, position, fromPosition)
 	if Tile(position):hasFlag(TILESTATE_PROTECTIONZONE) then
 		local lookPosition = player:getPosition()
 		lookPosition:getNextPosition(player:getDirection())
-		local depotItem = Tile(lookPosition):getItemByType(ITEM_TYPE_DEPOT)
-		if depotItem ~= nil then
-			local depotItems = player:getDepotLocker(getDepotId(depotItem:getUniqueId()), true):getItemHoldingCount()
-			player:sendTextMessage(MESSAGE_STATUS_DEFAULT, "Your depot contains " .. depotItems .. " item" .. (depotItems > 1 and "s." or "."))
-			return true
+		local tileInFront = Tile(lookPosition)
+		if tileInFront then
+			local depotItem = tileInFront:getItemByType(ITEM_TYPE_DEPOT)
+			if depotItem ~= nil then
+				local depotItems = player:getDepotLocker(getDepotId(depotItem:getUniqueId()), true):getItemHoldingCount()
+				player:sendTextMessage(MESSAGE_STATUS_DEFAULT, "Your depot contains " .. depotItems .. " item" .. (depotItems > 1 and "s." or "."))
+				return true
+			end
 		end
 	end
 


### PR DESCRIPTION
This change fixes an issue occurring when player gets teleported to (or walks on) tile with protection zone flag and without a valid tile in front of him. Example of such situation is shown on this screenshot: https://tibia.fandom.com/wiki/Dreamer%27s_Challenge_Quest?file=Dreamers5.JPG In this case an engine tries to perform getDepotLocker on nil type object and result in throwing an error. For this reason checking if a tile in front of player is valid before performing getDepotLocker method seems to be reasonable, which was done in this small update.