### PR TITLE
Fix yellow skull behavior

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3259,14 +3259,17 @@ void Player::onAttackedCreature(Creature* target)
 					pzLocked = true;
 					sendIcons();
 				}
+
 				if (!Combat::isInPvpZone(this, targetPlayer) && !isInWar(targetPlayer)) {
-					addAttacked(targetPlayer);
+					// Verify if attacked player has not previously been attacked by the player with the white skull
+					if (!targetPlayer->hasAttacked(this) && getSkull() != SKULL_WHITE) {
+						addAttacked(targetPlayer);
+						targetPlayer->sendCreatureSkull(this);
+					}
+
 					if (targetPlayer->getSkull() == SKULL_NONE && getSkull() == SKULL_NONE) {
 						setSkull(SKULL_WHITE);
 					}
-				}
-				if (getSkull() == SKULL_NONE) {
-					targetPlayer->sendCreatureSkull(this);
 				}
 			}
 		}


### PR DESCRIPTION
Verify if attacked player has not previously been attacked by the player with the white skull. If the player has been previously attacked, and fight back he do not get yellow skull.
Fix https://github.com/celohere/forgottenserver/issues/55