### PR TITLE
missing cstdint

### DIFF
--- a/src/definitions.h
+++ b/src/definitions.h
@@ -39,6 +39,8 @@
 #include <cmath>
 #include <string>
 #include <vector>
+#include <cstdint>
+
 
 #ifdef _WIN32
 #ifndef NOMINMAX


### PR DESCRIPTION
older versions of gcc would include it implicitly in one of the other includes, but newer versions of gcc like 13.2.0 does not, leading to errors like

```
/home/hans/projects/POTCP/forgottenserver/src/definitions.h:42:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
```