### PR TITLE
FIx not checking world to add player on vip list

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2807,8 +2807,15 @@ void Game::playerRequestAddVip(uint32_t playerId, const std::string& name)
 		uint32_t guid;
 		bool specialVip;
 		std::string formattedName = name;
-		if (!IOLoginData::getGuidByNameEx(guid, specialVip, formattedName)) {
+		uint16_t targetWorldId;
+
+		if (!IOLoginData::getGuidByNameEx(guid, specialVip, formattedName, targetWorldId)) {
 			player->sendTextMessage(MESSAGE_STATUS_SMALL, "A player with this name does not exist.");
+			return;
+		}
+
+		if (targetWorldId != player->getWorldId()) {
+			player->sendTextMessage(MESSAGE_STATUS_SMALL, "You can only add players from your world.");
 			return;
 		}
 

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -1014,12 +1014,12 @@ uint32_t IOLoginData::getGuidByName(const std::string& name)
 	return result->getNumber<uint32_t>("id");
 }
 
-bool IOLoginData::getGuidByNameEx(uint32_t& guid, bool& specialVip, std::string& name)
+bool IOLoginData::getGuidByNameEx(uint32_t& guid, bool& specialVip, std::string& name, uint16_t& worldId)
 {
 	Database* db = Database::getInstance();
 
 	std::ostringstream query;
-	query << "SELECT `name`, `id`, `group_id`, `account_id` FROM `players` WHERE `name` = " << db->escapeString(name);
+	query << "SELECT `name`, `id`, `group_id`, `account_id`, `world_id` FROM `players` WHERE `name` = " << db->escapeString(name);
 	DBResult_ptr result = db->storeQuery(query.str());
 	if (!result) {
 		return false;
@@ -1027,6 +1027,8 @@ bool IOLoginData::getGuidByNameEx(uint32_t& guid, bool& specialVip, std::string&
 
 	name = result->getString("name");
 	guid = result->getNumber<uint32_t>("id");
+	worldId = result->getNumber<uint16_t>("world_id");
+
 	Group* group = g_game.groups.getGroup(result->getNumber<uint16_t>("group_id"));
 
 	uint64_t flags;

--- a/src/iologindata.h
+++ b/src/iologindata.h
@@ -51,7 +51,7 @@ class IOLoginData
 		static bool loadPlayer(Player* player, DBResult_ptr result);
 		static bool savePlayer(Player* player);
 		static uint32_t getGuidByName(const std::string& name);
-		static bool getGuidByNameEx(uint32_t& guid, bool& specialVip, std::string& name);
+		static bool getGuidByNameEx(uint32_t& guid, bool& specialVip, std::string& name, uint16_t& worldId);
 		static std::string getNameByGuid(uint32_t guid);
 		static bool formatPlayerName(std::string& name);
 		static bool addStorageValue(uint32_t guid, uint32_t storageKey, uint32_t storageValue);


### PR DESCRIPTION
Problem explanation:
Previous behavior: Players could add players from another worlds in their vip list.
Solution:
Current behavior: When a player try to add someone from another world in his vip list the action fail and returns the message "You can only add players from your world."